### PR TITLE
Wire H3 surface for MEOS-only builds and headers

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -188,6 +188,7 @@ if(RGEO)
   set(PROJECT_OBJECTS ${PROJECT_OBJECTS} "$<TARGET_OBJECTS:rgeo>")
 endif()
 if(H3)
+  message(STATUS "Including temporal H3 index objects")
   set(PROJECT_OBJECTS ${PROJECT_OBJECTS} "$<TARGET_OBJECTS:h3>")
 endif()
 
@@ -217,6 +218,9 @@ target_link_libraries(${MEOS_LIB_NAME} ${GEOS_LIBRARY})
 target_link_libraries(${MEOS_LIB_NAME} ${PROJ_LIBRARIES})
 target_link_libraries(${MEOS_LIB_NAME} ${GSL_LIBRARY})
 target_link_libraries(${MEOS_LIB_NAME} ${GSL_CBLAS_LIBRARY})
+if(H3)
+  target_link_libraries(${MEOS_LIB_NAME} ${H3_LIBRARY})
+endif()
 
 #--------------------------------
 # Belongs to MEOS
@@ -267,6 +271,11 @@ endif()
 if(RGEO)
   install(
     FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_rgeo.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+if(H3)
+  install(
+    FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_h3.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
 


### PR DESCRIPTION
Building MEOS standalone with -DMEOS=ON -DH3=ON failed because the MEOS CMakeLists did not actually link or install any H3 pieces. The temporal H3 object set was added to PROJECT_OBJECTS but libh3 itself was never passed to target_link_libraries, so the link step left every th3index symbol undefined when the host did not pull libh3 in transitively. The public header meos_h3.h was likewise never installed, so downstream consumers such as the JMEOS regen could not find the th3index API after a clean install. Add the missing target_link_libraries call and the install rule for meos_h3.h, both guarded on H3 so non-H3 builds are unchanged, and add a configure-time status line matching the surrounding feature blocks.