### PR TITLE
Add atValues/minusValues for trgeometry (restrict by pose)

### DIFF
--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1066,13 +1066,12 @@ trgeometry_set_interp(const Temporal *temp, interpType interp)
 
 /**
  * @ingroup meos_internal_rgeo_restrict
- * @brief Restrict a temporal rigid geometry to (the complement of) a geometry
+ * @brief Restrict a temporal rigid geometry to (the complement of) a pose
  * @param[in] temp Temporal rigid geometry
  * @param[in] value Value
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @note This function does a bounding box test for the temporal types
- * different from instant. The singleton tests are done in the functions for
- * the specific temporal types.
+ * @note A temporal rigid geometry is restricted by pose: strip to the temporal
+ * pose, restrict, and re-attach the reference geometry.
  * @csqlfn #Temporal_restrict_value()
  */
 Temporal *
@@ -1081,7 +1080,9 @@ trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *res = temporal_restrict_value(temp, value, atfunc);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  Temporal *res = temporal_restrict_value(tpose, value, atfunc);
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1120,7 +1121,7 @@ trgeo_minus_value(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_internal_rgeo_restrict
  * @brief Restrict a temporal rigid geometry to (the complement of) a set of
- * geometries
+ * poses
  * @param[in] temp Temporal rigid geometry
  * @param[in] s Set of values
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
@@ -1130,8 +1131,10 @@ Temporal *
 trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_GEOMSET(s, NULL); 
-  Temporal *res = temporal_restrict_values(temp, s, atfunc);
+  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_POSESET(s, NULL);
+  Temporal *tpose = trgeometry_to_tpose(temp);
+  Temporal *res = temporal_restrict_values(tpose, s, atfunc);
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geo_tpose_to_trgeometry(trgeo_geom_p(temp), res);

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -61,6 +61,10 @@
 #include "temporal/type_parser.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tspatial_parser.h"
+#if RGEO
+  #include <meos_rgeo.h>
+  #include "rgeo/trgeo.h"
+#endif /* RGEO */
 
 /*****************************************************************************
  * Bounding box tests for the restriction functions
@@ -152,17 +156,24 @@ Temporal *
 temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); 
+  VALIDATE_NOT_NULL(temp, NULL);
+#if RGEO
+  /* Temporal rigid geometries are restricted by pose: strip to the temporal
+   * pose, restrict, and re-attach the reference geometry */
+  if (temp->temptype == T_TRGEOMETRY)
+  {
+    Temporal *tpose = trgeometry_to_tpose(temp);
+    Temporal *rest = temporal_restrict_value(tpose, value, atfunc);
+    Temporal *result = rest ?
+      geo_tpose_to_trgeometry(trgeo_geom_p(temp), rest) : NULL;
+    pfree(tpose);
+    if (rest) pfree(rest);
+    return result;
+  }
+#endif /* RGEO */
   if (tspatial_type(temp->temptype))
   {
-#if RGEO
-    /* Temporal rigid geometries have poses as base values but are restricted
-     * to geometries */
-    MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-      temptype_basetype(temp->temptype);
-#else
     MeosType basetype = temptype_basetype(temp->temptype);
-#endif /* RGEO */
     if (! ensure_same_srid(tspatial_srid(temp),
             spatial_srid(value, basetype)) ||
         ! ensure_same_spatial_dimensionality(temp->flags,
@@ -243,10 +254,23 @@ temporal_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_temporal_set(temp, s) ||
-     (tspatial_type(temp->temptype) && 
+     (tspatial_type(temp->temptype) &&
       (! ensure_same_srid(tspatial_srid(temp), spatialset_srid(s)) ||
        ! ensure_same_spatial_dimensionality(temp->flags, s->flags))))
     return NULL;
+
+#if RGEO
+  if (temp->temptype == T_TRGEOMETRY)
+  {
+    Temporal *tpose = trgeometry_to_tpose(temp);
+    Temporal *rest = temporal_restrict_values(tpose, s, atfunc);
+    Temporal *result = rest ?
+      geo_tpose_to_trgeometry(trgeo_geom_p(temp), rest) : NULL;
+    pfree(tpose);
+    if (rest) pfree(rest);
+    return result;
+  }
+#endif /* RGEO */
 
   /* Singleton set */
   if (s->count == 1)

--- a/mobilitydb/sql/rgeo/122_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/122_trgeo.in.sql
@@ -476,25 +476,22 @@ CREATE FUNCTION tsample(trgeometry, duration interval,
  * Restriction Functions
  *****************************************************************************/
 
--- CREATE FUNCTION atValues(trgeometry, geometry)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_at_value'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- CREATE FUNCTION minusValues(trgeometry, geometry)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_minus_value'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- CREATE FUNCTION atValues(trgeometry, geomset)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_at_values'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- CREATE FUNCTION minusValues(trgeometry, geomset)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_minus_values'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atValues(trgeometry, pose)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_at_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValues(trgeometry, pose)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_minus_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atValues(trgeometry, poseset)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_at_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValues(trgeometry, poseset)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_minus_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION atTime(trgeometry, timestamptz)
   RETURNS trgeometry


### PR DESCRIPTION
Stacked on the rename PR #1067 (provides the renamed `geo_tpose_to_trgeometry` / `trgeometry_to_tpose` converters). Rebase onto master once #1067 lands. Part of the cross-type parity completion; integrated evidence = accumulate fork PR #22.