### PR TITLE
Make the vendored pgtypes MEOS includes resolvable in the standalone build

### DIFF
--- a/pgtypes/CMakeLists.txt
+++ b/pgtypes/CMakeLists.txt
@@ -159,4 +159,9 @@ add_library(pgtypes STATIC ${PGTYPES_SOURCES})
 
 target_include_directories(pgtypes PUBLIC "${CMAKE_SOURCE_DIR}/pgtypes")
 target_include_directories(pgtypes PUBLIC "${CMAKE_BINARY_DIR}/pgtypes")
+# The pgtypes sources include the MEOS public headers (meos.h, meos_error.h,
+# meos_tls.h); expose meos/include on the target so they resolve from any
+# pgtypes subdirectory depth (a relative ../../meos/include path only resolved
+# for the depth-2 files and broke the standalone -DMEOS build of the others).
+target_include_directories(pgtypes PUBLIC "${CMAKE_SOURCE_DIR}/meos/include")
 

--- a/pgtypes/common/stringinfo.c
+++ b/pgtypes/common/stringinfo.c
@@ -22,7 +22,7 @@
 #include "utils/datetime.h"
 #if MEOS
   #define MaxAllocSize   ((Size) 0x3fffffff) /* 1 gigabyte - 1 */
-  #include "../../meos/include/meos.h"
+  #include "meos.h"
 #else
   #include <utils/memutils.h>
 #endif

--- a/pgtypes/postgres.h
+++ b/pgtypes/postgres.h
@@ -71,7 +71,7 @@
 #endif
 #define EXIT_FAILURE 1
 
-#include "../../meos/include/meos_error.h"
+#include "meos_error.h"
 
 // /* MEOS: redefining palloc0, palloc, and pfree */
 // #if MEOS

--- a/pgtypes/utils/datetime.c
+++ b/pgtypes/utils/datetime.c
@@ -24,7 +24,7 @@
 #include "parser/scansup.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
-#include "../../meos/include/meos.h"
+#include "meos.h"
 #include "utils/datetime.h"
 #include "utils/tzparser.h"
 


### PR DESCRIPTION
The pgtypes sources include the MEOS public headers (`meos.h`, `meos_error.h`, `meos_tls.h`) via a hardcoded depth-2 relative path `../../meos/include/<h>`. The pgtypes sources live at depths 1..4 under `pgtypes/`, so that path only resolves for the depth-2 files; the **standalone pgtypes build** (the minimal build used by MobilityDuck, MobilitySpark/JMEOS and MobilityNebula — which does not leak `meos/include` onto the pgtypes compile the way the full MEOS/extension builds do) breaks on the others:

```
pgtypes/postgres.h:74: fatal error: meos_error.h: No such file or directory
```

**Fix:** expose `${CMAKE_SOURCE_DIR}/meos/include` on the pgtypes target's include directories (depth-independent) and drop the fragile `../../` prefix. The PG extension is unaffected (it uses the real PostgreSQL headers, not the vendored `pgtypes/`).

Stacks on #751 (which introduces `pgtypes/`). Verified: clean-room compile of a depth-3 source fails without the include dir and resolves with it; standalone `-DMEOS=ON` and the PG extension both build.